### PR TITLE
Updated Statamic version requirements for addon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require": {
     "php": "^7.4 || ^8.0",
     "illuminate/support": "^7.0 || ^8.0",
-    "statamic/cms": "3.0.*",
+    "statamic/cms": "3.0.* || 3.1.*",
     "ohdearapp/ohdear-php-sdk": "^3.0.1"
   },
   "extra": {


### PR DESCRIPTION
Pull request is for the installation issue when using Statamic 3.1. 

Reference issue #5 