### PR TITLE
fix controller not found error

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -6,10 +6,16 @@
 |--------------------------------------------------------------------------
 */
 
+use Jonassiewertsen\OhDear\Http\Controllers\BrokenLinksController;
+use Jonassiewertsen\OhDear\Http\Controllers\CertificateHealthController;
+use Jonassiewertsen\OhDear\Http\Controllers\MixedContentController;
+use Jonassiewertsen\OhDear\Http\Controllers\OverviewController;
+use Jonassiewertsen\OhDear\Http\Controllers\UptimeController;
+
 Route::prefix('oh-dear/')->name('oh-dear.')->group(function() {
-    Route::get('/', 'OverviewController@index')->name('index');
-    Route::get('/uptime', 'UptimeController@index')->name('uptime');
-    Route::get('/broken-links', 'BrokenLinksController@index')->name('broken-links');
-    Route::get('/mixed-content', 'MixedContentController@index')->name('mixed-content');
-    Route::get('/certificate-health', 'CertificateHealthController@index')->name('certificate-health');
+    Route::get('/', OverviewController::class)->name('index');
+    Route::get('/uptime', UptimeController::class)->name('uptime');
+    Route::get('/broken-links', BrokenLinksController::class)->name('broken-links');
+    Route::get('/mixed-content', MixedContentController::class)->name('mixed-content');
+    Route::get('/certificate-health', CertificateHealthController::class)->name('certificate-health');
 });

--- a/src/Http/Controllers/BrokenLinksController.php
+++ b/src/Http/Controllers/BrokenLinksController.php
@@ -4,7 +4,7 @@ namespace Jonassiewertsen\OhDear\Http\Controllers;
 
 class BrokenLinksController extends Controller
 {
-    public function index()
+    public function __invoke()
     {
         $this->authorize('show ohdear');
 

--- a/src/Http/Controllers/CertificateHealthController.php
+++ b/src/Http/Controllers/CertificateHealthController.php
@@ -4,7 +4,7 @@ namespace Jonassiewertsen\OhDear\Http\Controllers;
 
 class CertificateHealthController extends Controller
 {
-    public function index()
+    public function __invoke()
     {
         $this->authorize('show ohdear');
 

--- a/src/Http/Controllers/MixedContentController.php
+++ b/src/Http/Controllers/MixedContentController.php
@@ -4,7 +4,7 @@ namespace Jonassiewertsen\OhDear\Http\Controllers;
 
 class MixedContentController extends Controller
 {
-    public function index()
+    public function __invoke()
     {
         $this->authorize('show ohdear');
 

--- a/src/Http/Controllers/OverviewController.php
+++ b/src/Http/Controllers/OverviewController.php
@@ -4,7 +4,7 @@ namespace Jonassiewertsen\OhDear\Http\Controllers;
 
 class OverviewController extends Controller
 {
-    public function index()
+    public function __invoke()
     {
         $this->authorize('show ohdear');
 

--- a/src/Http/Controllers/UptimeController.php
+++ b/src/Http/Controllers/UptimeController.php
@@ -4,7 +4,7 @@ namespace Jonassiewertsen\OhDear\Http\Controllers;
 
 class UptimeController extends Controller
 {
-    public function index()
+    public function __invoke()
     {
         $this->authorize('show ohdear');
 


### PR DESCRIPTION
In Statamic 4 the controllers were not found. The upgrade guide recommends to use class reference.

https://statamic.dev/upgrade-guide/3-4-to-4-0#route-namespaces-have-been-removed

This PR refactors the routes.